### PR TITLE
Avoid warning message when widget area is empty

### DIFF
--- a/src/StaticApi/Widgets.php
+++ b/src/StaticApi/Widgets.php
@@ -26,17 +26,19 @@ class Widgets
 
 			$widget_areas[ $widget_area ] = [];
 
-			foreach ( $widgets as $widget ) {
-				$model = Register::get_widget_instance( $widget );
+			if ( ! empty( $widgets ) ) {
+				foreach ( $widgets as $widget ) {
+					$model = Register::get_widget_instance( $widget );
 
-				if ( ! $model ) {
-					continue;
+					if ( ! $model ) {
+						continue;
+					}
+
+					$widget_areas[ $widget_area ][] = [
+						'type' => $model->get_slug(),
+						'content' => $model->get_data(),
+					];
 				}
-
-				$widget_areas[ $widget_area ][] = [
-					'type' => $model->get_slug(),
-					'content' => $model->get_data(),
-				];
 			}
 		}
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Bugfix
- **What is the current behavior?** (You can also link to an open issue
  here)

When a widget area is empty we get a warning message

```
<br />
<b>Warning</b>:  Invalid argument supplied for foreach() in <b>/srv/www/shootx9/htdocs/wp-content/plugins/shootx9/vendor/moxie-leean/wp-endpoints-static/src/StaticApi/Widgets.php</b> on line <b>29</b><br />
```
- **What is the new behavior (if this is a feature change)?**

No warnings
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No
- **Other information**:

I need a new version released too.
